### PR TITLE
Catch exception in ChangesPostfix and add config option for generating value proxies on reference proxies

### DIFF
--- a/ValueProxyExtensions/Properties/AssemblyInfo.cs
+++ b/ValueProxyExtensions/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyFileVersion("1.1.1")]


### PR DESCRIPTION
Fixes #3 

Adds a config option for whether reference proxies should act as value proxies with the full type name.

Also fixes Display_Float3 (and possibly other display nodes) becoming disabled when you leave and rejoin a session.